### PR TITLE
Update builder workflow for GitHub Actions Node.js 24 migration

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -36,10 +36,11 @@ jobs:
         id: changed_addons
         run: |
           declare -a changed_addons
+          changed_files="${{ steps.changed_files.outputs.all_changed_files }} ${{ steps.changed_files.outputs.deleted_files }}"
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all_changed_files }}" =~ $addon ]]; then
+            if [[ "${changed_files}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all_changed_files }}" =~ $addon/$file ]]; then
+                  if [[ "${changed_files}" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -3,6 +3,7 @@ name: Builder
 env:
   BUILD_ARGS: "--test"
   MONITORED_FILES: "config.yaml Dockerfile rootfs"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 on:
   push:
@@ -25,7 +26,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: tj-actions/changed-files@v47
 
       - name: Find app directories
         id: addons
@@ -36,9 +37,9 @@ jobs:
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "${{ steps.changed_files.outputs.all_changed_files }}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "${{ steps.changed_files.outputs.all_changed_files }}" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi


### PR DESCRIPTION
### Motivation
- Replace a deprecated Node.js 20-based action and make the builder workflow compatible with the upcoming Node.js 24 runtime change. 
- Ensure the changed-files lookup logic continues to work with a maintained action and opt the workflow into Node.js 24 now.

### Description
- Replace `jitterbit/get-changed-files@v1` with `tj-actions/changed-files@v47` in `.github/workflows/builder.yaml`.
- Update changed-files output references from `steps.changed_files.outputs.all` to `steps.changed_files.outputs.all_changed_files` where the script checks for changed addons and monitored files.
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the workflow `env` to opt into the Node.js 24 JavaScript actions runtime.

### Testing
- Validated the modified workflow file with Ruby YAML loader using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/builder.yaml'); puts 'YAML OK'"`, which succeeded.
- Attempted to parse the file with Python `yaml.safe_load`, but that run failed because the `PyYAML` module is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2aa3664c832cb5d9d4bcf148d360)