### PR TITLE
Builder workflow: add manual dispatch and beta deploy gating

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -13,6 +13,17 @@ on:
     branches:
       - main
       - beta
+  workflow_dispatch:
+    inputs:
+      deploy_beta:
+        description: "Deploy beta build (publish images from beta branch)"
+        required: false
+        default: false
+        type: boolean
+      addon:
+        description: "Optional addon directory to build"
+        required: false
+        type: string
 
 jobs:
   init:
@@ -36,6 +47,13 @@ jobs:
       - name: Get changed apps
         id: changed_addons
         run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ -n "${{ inputs.addon }}" ]]; then
+            echo "Manual workflow_dispatch build for addon: ${{ inputs.addon }}";
+            echo "changed=true" >> $GITHUB_OUTPUT;
+            echo "addons=[\"${{ inputs.addon }}\"]" >> $GITHUB_OUTPUT;
+            exit 0
+          fi
+
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
             if [[ "${{ steps.changed_files.outputs.all_modified_files }}" =~ $addon ]]; then
@@ -90,13 +108,19 @@ jobs:
           elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
             echo "build_arch=true" >> $GITHUB_OUTPUT;
             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-            if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+                echo "BUILD_ARGS=" >> $GITHUB_ENV;
+            elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ github.ref }}" == "refs/heads/beta" ]] && [[ "${{ inputs.deploy_beta }}" == "true" ]]; then
                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
             fi
           else
             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
             echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
+
+      - name: Beta test build only
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/beta' && inputs.deploy_beta != true
+        run: echo "beta test build only"
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'


### PR DESCRIPTION
### Motivation
- Allow manual runs of the builder workflow and safely control whether beta branch runs publish images.
- Prevent automatic publishing from beta pushes while keeping `push` triggers on both `main` and `beta` for test builds.
- Provide a way to target a single addon for manual builds.

### Description
- Add `workflow_dispatch` trigger with `deploy_beta` (boolean) and optional `addon` inputs in `.github/workflows/builder.yaml`.
- Update the `Get changed apps` step to honor `inputs.addon` for manual `workflow_dispatch` runs and short-circuit changed-files detection when provided.
- Only clear `BUILD_ARGS` (enter deploy mode) when the event is a `push` to `refs/heads/main` or when `workflow_dispatch` targets `refs/heads/beta` with `inputs.deploy_beta == true`.
- Add a `Beta test build only` informational step for manual beta dispatches when `deploy_beta` is false and keep GHCR login gated by `env.BUILD_ARGS != '--test'`.

### Testing
- Parsed the modified workflow YAML with Ruby using `ruby -ryaml -e 'YAML.load_file(".github/workflows/builder.yaml"); puts "ok"'`, which succeeded.
- Attempted to parse with Python using `python - <<'PY' import yaml ... PY`, which failed due to a missing `PyYAML` module in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b64addfc832c820c43c45f48fbea)